### PR TITLE
Add ESA tips email and note tracking

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders customer onboarding pipeline', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/customer onboarding pipeline/i);
+  expect(headerElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- require valid parent email when adding customers
- allow tracking ESA fund usage with optional ESA tips email
- add internal notes with timestamps and show email send times

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689304e2c610832fb6ccd3629e8787fa