### PR TITLE
feat: send email via webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# URL of the deployed Google Apps Script web-app used for sending emails
+REACT_APP_EMAIL_WEBHOOK_URL=

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Alpha Anywhere - Customer Onboarding/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- send onboarding emails via Google Apps Script webhook
- surface network errors and gate timeline updates on success
- document `REACT_APP_EMAIL_WEBHOOK_URL` configuration

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68930ceeb788832fb4e594e2e18e8d9a