### PR TITLE
Integrate Google Apps Script email relay

### DIFF
--- a/google-apps-script/emailRelay.gs
+++ b/google-apps-script/emailRelay.gs
@@ -1,0 +1,15 @@
+function doPost(e) {
+  var data = JSON.parse(e.postData.contents);
+
+  GmailApp.sendEmail(data.to, data.subject, '', {
+    htmlBody: data.htmlContent,
+    name: data.fromName,
+    replyTo: data.from,
+    from: data.from
+  });
+
+  return ContentService
+    .createTextOutput(JSON.stringify({ success: true }))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*');
+}

--- a/src/App.js
+++ b/src/App.js
@@ -325,6 +325,10 @@ Best regards,
 
     try {
       const webhookUrl = process.env.REACT_APP_EMAIL_WEBHOOK_URL;
+      if (!webhookUrl) {
+        throw new Error('Missing email webhook URL');
+      }
+
       const payload = {
         to: customer.parentEmail,
         from: senderEmail,

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/alpha anywhere - customer onboarding/i);
+  expect(headerElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- send email data to Apps Script webhook and update status
- add Google Apps Script `doPost` implementation for email relay
- align unit test with new app header

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68930fe98aa0832fa07f8b52e709d038