### PR TITLE
Fetch email templates from Supabase

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /Alpha Anywhere - Customer Onboarding/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,9 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
-console.log('Supabase URL:', supabaseUrl);
-console.log('Anon Key (first 10 chars):', supabaseAnonKey?.substring(0, 10));
 
 // These come from your Supabase project settings → API
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.REACT_APP_SUPABASE_URL || 'http://localhost';
+const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY || 'public-anon-key';
+
+console.log('Supabase URL:', supabaseUrl);
+console.log('Anon Key (first 10 chars):', supabaseAnonKey?.substring(0, 10));
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- load email templates from Supabase at startup
- handle missing templates gracefully when building emails
- update tests and Supabase client setup

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68934d1503f8832fbdc5260d63bc07d8