### PR TITLE
Fix Supabase client import path inside src

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabase } from './supabaseClient.js';
 import ParentForm from './components/ParentForm';
 import CustomerTable from './components/CustomerTable';
 import StepControls from './components/StepControls';

--- a/src/components/CustomerTable.js
+++ b/src/components/CustomerTable.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient.js';
 
 export default function CustomerTable({ onSelect, reload = 0 }) {
   const [rows, setRows] = useState([]);

--- a/src/components/EmailLogs.js
+++ b/src/components/EmailLogs.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient.js';
 
 export default function EmailLogs({ customerId }) {
   const [logs, setLogs] = useState([]);

--- a/src/components/EmailTemplates.js
+++ b/src/components/EmailTemplates.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient.js';
 import RichTextEditor from './RichTextEditor';
 
 export default function EmailTemplates() {

--- a/src/components/Notes.js
+++ b/src/components/Notes.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient.js';
 
 export default function Notes({ customerId }) {
   const [notes, setNotes] = useState([]);

--- a/src/components/ParentForm.js
+++ b/src/components/ParentForm.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient.js';
 
 export default function ParentForm({ onCreated }) {
   const [form, setForm] = useState({

--- a/src/components/StaffManager.js
+++ b/src/components/StaffManager.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient.js';
 
 export default function StaffManager() {
   const [staff, setStaff] = useState([]);

--- a/src/components/StepControls.js
+++ b/src/components/StepControls.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../supabaseClient.js';
 
 export default function StepControls({ customer, onUpdated }) {
   const [c, setC] = useState(customer);


### PR DESCRIPTION
## Summary
- Use explicit `.js` extensions when importing Supabase client to avoid referencing files outside `src`
- Update components to reference the client from within the `src` tree

## Testing
- `CI=true npm test` *(fails: Unable to find element with text /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_6893ffeb8738832fbfd15bb1bdd72a66